### PR TITLE
Improve memory read timing by removing readData signals

### DIFF
--- a/src/main/scala/Fetch.scala
+++ b/src/main/scala/Fetch.scala
@@ -8,7 +8,6 @@ class Fetch(val bits: Int, val words: Int) extends Module {
     val mem = new MemoryPort(bits, words, false)
   })
 
-  io.mem.readEnable := true.B
   io.mem.addr := io.nia >> log2Ceil(bits/8)
 
   /* Issues with conditional entries in ports */

--- a/src/main/scala/LoadStore.scala
+++ b/src/main/scala/LoadStore.scala
@@ -44,7 +44,6 @@ class LoadStore(val bits: Int, val words: Int) extends Module {
   io.out.bits := 0.U
 
   io.mem.addr := 0.U
-  io.mem.readEnable := false.B
   io.mem.writeMask := 0.U
   io.mem.writeData := 0.U
   io.mem.writeEnable := false.B
@@ -132,7 +131,6 @@ class LoadStore(val bits: Int, val words: Int) extends Module {
         state := sIdle
       } .otherwise {
         io.mem.addr := addr >> log2Ceil(bits/8).U
-        io.mem.readEnable := true.B
         state := sLoadFormat
       }
     }
@@ -194,7 +192,6 @@ class LoadStoreWrapper(val bits: Int, val size: Int, filename: String) extends M
 
   /* Fetch port is unused */
   mem.io.fetchPort.writeData := 0.U
-  mem.io.fetchPort.readEnable := false.B
   mem.io.fetchPort.writeEnable := false.B
   mem.io.fetchPort.addr := 0.U
   mem.io.fetchPort.writeMask := 0.U

--- a/src/test/scala/MemoryBlackBox.scala
+++ b/src/test/scala/MemoryBlackBox.scala
@@ -19,11 +19,9 @@ class MemoryBlackBoxUnitTester extends FlatSpec with ChiselScalatestTester with 
   behavior of "MemoryBlackBox"
   it should "pass a unit test" in {
     test(new MemoryBlackBoxWrapper(bits, words, filename)).withAnnotations(Seq(VerilatorBackendAnnotation, WriteVcdAnnotation, ClockInfoAnnotation(Seq(ClockInfo(period = 2))))) { m =>
-      m.io.fetchPort.readEnable.poke(true.B)
 
       m.io.fetchPort.addr.poke(0.U)
 
-      m.io.fetchPort.readEnable.expect(true.B)
       m.clock.step()
       m.io.fetchPort.readData.expect("h0001020304050607".U)
 


### PR DESCRIPTION
There's no need to gate reads.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>