### PR TITLE
Add Colorlight 5A-75B support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,14 @@ NEXTPNR_FLAGS=--um5g-85k --freq 12
 OPENOCD_JTAG_CONFIG=openocd/ecp5-evn.cfg
 OPENOCD_DEVICE_CONFIG=openocd/LFE5UM5G-85F.cfg
 
+# Colorlight 5A-75B
+#LPF=constraints/colorlight_5A-75B.lpf
+#PLL=pll/pll_ehxplll_25MHz.v
+#PACKAGE=CABGA256
+#NEXTPNR_FLAGS=--25k --freq 25
+#OPENOCD_JTAG_CONFIG=openocd/olimex-arm-usb-tiny-h.cfg
+#OPENOCD_DEVICE_CONFIG=openocd/LFE5U-25F.cfg
+
 synth: chiselwatt.bit
 
 chiselwatt.json: insns.hex $(verilog_files) $(PLL) toplevel.v

--- a/constraints/colorlight_5A-75B.lpf
+++ b/constraints/colorlight_5A-75B.lpf
@@ -1,0 +1,25 @@
+# All the I/Os on this board go through bidirectional level shifters that
+# appear to be hardwired as outputs. To get an input pin for UART RX, we
+# use the button I/O which is also routed to connector J19. The downside is
+# we can't use the button for reset.
+
+LOCATE COMP "clock" SITE "P6";
+IOBUF PORT "clock" IO_TYPE=LVCMOS33;
+
+# We need to assign reset to something to keep the tools happy
+LOCATE COMP "reset" SITE "F1";
+IOBUF PORT "reset" PULLMODE=UP IO_TYPE=LVCMOS33;
+
+LOCATE COMP "io_tx" SITE "F3";
+LOCATE COMP "io_rx" SITE "M13";
+
+IOBUF PORT "io_tx" IO_TYPE=LVCMOS33;
+IOBUF PORT "io_rx" IO_TYPE=LVCMOS33;
+
+LOCATE COMP "io_terminate" SITE "G3";
+LOCATE COMP "io_ledB" SITE "P11";
+LOCATE COMP "io_ledC" SITE "G2";
+
+IOBUF PORT "io_terminate" IO_TYPE=LVCMOS33;
+IOBUF PORT "io_ledB" IO_TYPE=LVCMOS25;
+IOBUF PORT "io_ledC" IO_TYPE=LVCMOS33;

--- a/pll/pll_ehxplll_25MHz.v
+++ b/pll/pll_ehxplll_25MHz.v
@@ -1,0 +1,36 @@
+module pll(
+  input  clki,
+  output clko,
+  output lock
+);
+  (* ICP_CURRENT="12" *) (* LPF_RESISTOR="8" *) (* MFG_ENABLE_FILTEROPAMP="1" *) (* MFG_GMCREF_SEL="2" *)
+
+  EHXPLLL #(
+    .PLLRST_ENA("DISABLED"),
+    .INTFB_WAKE("DISABLED"),
+    .STDBY_ENABLE("DISABLED"),
+    .DPHASE_SOURCE("DISABLED"),
+    .CLKOP_FPHASE(0),
+    .CLKOP_CPHASE(11),
+    .OUTDIVIDER_MUXA("DIVA"),
+    .CLKOP_ENABLE("ENABLED"),
+    .CLKOP_DIV(12),
+    .CLKFB_DIV(10),
+    .CLKI_DIV(5),
+    .FEEDBK_PATH("CLKOP")
+  ) pll_i (
+    .CLKI(clki),
+    .CLKFB(clko),
+    .CLKOP(clko),
+    .LOCK(lock),
+    .RST(1'b0),
+    .STDBY(1'b0),
+    .PHASESEL0(1'b0),
+    .PHASESEL1(1'b0),
+    .PHASEDIR(1'b0),
+    .PHASESTEP(1'b0),
+    .PLLWAKESYNC(1'b0),
+    .ENCLKOP(1'b0)
+  );
+
+endmodule


### PR DESCRIPTION
This adds support for the cheap Colorlight 5A-75B ECP5 based board.

UART RX is on J19, labelled key+ on the silk screen on the back
UART TX is on J1, pin 1.

All the I/Os on this board go through bidirectional level shifters that
appear to be hardwired as outputs. To get an input pin for UART RX, we
use the button I/O which is also routed to connector J19. The downside is
we can't use the button for reset.

One potential issue is that UART TX is 5V but UART RX is 3.3V. To keep
the FPGA happy any attached UART chip needs to output 3.3V, but it also
needs to be 5V tolerant to handle the level shifted input.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>