### PR TITLE
Fix make check issue

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -19,7 +19,7 @@ trait HasXsource211 extends ScalaModule {
 
 trait HasChisel3 extends ScalaModule {
   override def ivyDeps = Agg(
-    ivy"edu.berkeley.cs::chisel3:3.2.+"
+    ivy"edu.berkeley.cs::chisel3:3.2.5"
  )
 }
 


### PR DESCRIPTION
make check has stopped working recently:

  java.lang.ClassCastException: java.lang.Class cannot be cast to firrtl.options.Dependency
  at scala.collection.LinearSeqOptimized.foldLeft(LinearSeqOptimized.scala:126)
  at scala.collection.LinearSeqOptimized.foldLeft$(LinearSeqOptimized.scala:122)
  at scala.collection.immutable.List.foldLeft(List.scala:89)
  at firrtl.options.DependencyManager.firrtl$options$DependencyManager$$_targets(DependencyManager.scala:34)
  at firrtl.options.DependencyManager.firrtl$options$DependencyManager$$_targets$(DependencyManager.scala:33)
  at firrtl.options.PhaseManager.firrtl$options$DependencyManager$$_targets$lzycompute(DependencyManager.scala:414)
  at firrtl.options.PhaseManager.firrtl$options$DependencyManager$$_targets(DependencyManager.scala:414)
  at firrtl.options.DependencyManager.firrtl$options$DependencyManager$$prerequisiteGraph(DependencyManager.scala:115)
  at firrtl.options.DependencyManager.firrtl$options$DependencyManager$$prerequisiteGraph$(DependencyManager.scala:113)
  at firrtl.options.PhaseManager.firrtl$options$DependencyManager$$prerequisiteGraph$lzycompute(DependencyManager.scala:414)

I need to investigate, but setting chisel3 to 3.2.5 fixes it for now.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>