### PR TITLE
Add support for Microsemi Polarfire FPGA

### DIFF
--- a/chiselwatt.core
+++ b/chiselwatt.core
@@ -1,6 +1,6 @@
 CAPI=2:
 
-name : ::chiselwatt:0
+name: ::chiselwatt:0
 
 filesets:
   core:
@@ -8,81 +8,114 @@ filesets:
       - Core.v
       - MemoryBlackBox.v
       - toplevel.v
-      - insns.hex : {copyto : insns.hex, file_type : user}
-    file_type : verilogSource
+      - insns.hex: { copyto: insns.hex, file_type: user }
+    file_type: verilogSource
+
+  helloworld:
+    files:
+      - samples/binaries/hello_world/hello_world.hex:
+          { copyto: insns.hex, file_type: user }
+
+  micropython:
+    files:
+      - samples/binaries/micropython/firmware.hex:
+          { copyto: insns.hex, file_type: user }
 
   cmod_a7-35:
     files:
-      - constraints/cmod_a7-35.xdc : {file_type : xdc}
-      - pll/pll_mmcme2.v : {file_type : verilogSource}
+      - constraints/cmod_a7-35.xdc: { file_type: xdc }
+      - pll/pll_mmcme2.v: { file_type: verilogSource }
 
   arty_a7:
     files:
-      - constraints/arty_a7.xdc : {file_type : xdc}
-      - pll/pll_bypass.v : {file_type : verilogSource}
+      - constraints/arty_a7.xdc: { file_type: xdc }
+      - pll/pll_bypass.v: { file_type: verilogSource }
 
   nexys_video:
     files:
-      - constraints/nexys-video.xdc : {file_type : xdc}
-      - pll/pll_bypass.v : {file_type : verilogSource}
+      - constraints/nexys-video.xdc: { file_type: xdc }
+      - pll/pll_bypass.v: { file_type: verilogSource }
 
   ecp5-evn:
     files:
-      - constraints/ecp5-evn.lpf : {file_type : LPF}
-      - pll/pll_ehxplll.v : {file_type : verilogSource}
+      - constraints/ecp5-evn.lpf: { file_type: LPF }
+      - pll/pll_ehxplll.v: { file_type: verilogSource }
 
   ecp5-ulx3s:
     files:
-      - constraints/ecp5-ulx3s.lpf : {file_type : LPF}
-      - pll/pll_ehxplll_25MHz.v : {file_type : verilogSource}
+      - constraints/ecp5-ulx3s.lpf: { file_type: LPF }
+      - pll/pll_ehxplll_25MHz.v: { file_type: verilogSource }
+
+  polarfireeval:
+    files:
+      - constraints/polarfire_eval.pdc: { file_type: PDC }
+      - pll/pll_polarfire50MHz.v: { file_type: verilogSource }
 
 targets:
   cmod_a7-35:
     default_tool: vivado
     filesets: [core, cmod_a7-35]
-    parameters :
+    parameters:
       - RESET_LOW=false
     tools:
-      vivado: {part : xc7a35tcpg236-1}
-    toplevel : toplevel
+      vivado: { part: xc7a35tcpg236-1 }
+    toplevel: toplevel
 
   arty_a7-35:
     default_tool: vivado
     filesets: [core, arty_a7]
     tools:
-      vivado: {part : xc7a35ticsg324-1L}
-    toplevel : toplevel
+      vivado: { part: xc7a35ticsg324-1L }
+    toplevel: toplevel
 
   arty_a7-100:
     default_tool: vivado
     filesets: [core, arty_a7]
     tools:
-      vivado: {part : xc7a100ticsg324-1L}
-    toplevel : toplevel
+      vivado: { part: xc7a100ticsg324-1L }
+    toplevel: toplevel
 
   nexys_video:
     default_tool: vivado
     filesets: [core, nexys_video]
     tools:
-      vivado: {part : xc7a200tsbg484-1}
-    toplevel : toplevel
+      vivado: { part: xc7a200tsbg484-1 }
+    toplevel: toplevel
 
   ecp5-evn:
     default_tool: diamond
     filesets: [core, ecp5-evn]
     tools:
-      diamond: {part: LFE5U-85F-8BG381I}
-    toplevel : toplevel
+      diamond: { part: LFE5U-85F-8BG381I }
+    toplevel: toplevel
 
   ecp5-ulx3s:
     default_tool: diamond
     filesets: [core, ecp5-ulx3s]
     tools:
-      diamond: {part: LFE5U-85F-8BG381I}
-    toplevel : toplevel
+      diamond: { part: LFE5U-85F-8BG381I }
+    toplevel: toplevel
+
+  polarfireeval: &polarfireeval
+    default_tool: libero
+    description: Microsemi Polarfire Evaluation Kit
+    filesets: [core, polarfireeval, micropython]
+    tools:
+      libero: &liberoMPF300
+        family: PolarFire
+        die: MPF300TS
+        package: FCG1152
+    toplevel: toplevel
+
+  polarfireeval_es:
+    <<: *polarfireeval
+    tools:
+      libero:
+        <<: *liberoMPF300
+        die: MPF300TS_ES
 
 parameters:
   RESET_LOW:
-    datatype    : bool
-    description : External reset button polarity
-    paramtype   : generic
+    datatype: bool
+    description: External reset button polarity
+    paramtype: generic

--- a/constraints/polarfire_eval.pdc
+++ b/constraints/polarfire_eval.pdc
@@ -1,0 +1,9 @@
+set_io -port_name {clock} -pin_name E25 -io_std LVCMOS18 -fixed true
+set_io -port_name {reset} -pin_name K22 -io_std LVCMOS18 -fixed true
+
+set_io -port_name {io_tx} -pin_name G17 -io_std LVCMOS18 -fixed true
+set_io -port_name {io_rx} -pin_name H18 -io_std LVCMOS18 -fixed true
+
+set_io -port_name {io_terminate} -pin_name F22 -io_std LVCMOS18 -fixed true
+set_io -port_name {io_ledB} -pin_name B26 -io_std LVCMOS18 -fixed true
+set_io -port_name {io_ledC} -pin_name C26 -io_std LVCMOS18 -fixed true

--- a/pll/pll_bypass.v
+++ b/pll/pll_bypass.v
@@ -1,4 +1,4 @@
-module pll(
+module Chiselwatt_pll(
   input  clki,
   output reg clko,
   output reg lock

--- a/pll/pll_ehxplll.v
+++ b/pll/pll_ehxplll.v
@@ -1,4 +1,4 @@
-module pll(
+module Chiselwatt_pll(
   input  clki,
   output clko,
   output lock

--- a/pll/pll_ehxplll_25MHz.v
+++ b/pll/pll_ehxplll_25MHz.v
@@ -1,4 +1,4 @@
-module pll(
+module Chiselwatt_pll(
   input  clki,
   output clko,
   output lock

--- a/pll/pll_mmcme2.v
+++ b/pll/pll_mmcme2.v
@@ -1,4 +1,4 @@
-module pll(
+module Chiselwatt_pll(
   input  clki,
   output clko,
   output lock

--- a/pll/pll_polarfire50MHz.v
+++ b/pll/pll_polarfire50MHz.v
@@ -1,0 +1,66 @@
+`timescale 1 ns/100 ps
+// Version: v12.5 12.900.10.16
+
+
+module Chiselwatt_pll(
+       clki,
+       lock,
+       clko
+    );
+output clko;
+output lock;
+input  clki;
+
+    wire gnd_net, vcc_net, pll_inst_0_clkint_0;
+
+    CLKINT clkint_0 (.A(pll_inst_0_clkint_0), .Y(clko));
+    PLL #( .VCOFREQUENCY(5000), .DELAY_LINE_SIMULATION_MODE(""), .DATA_RATE(0.0)
+        , .FORMAL_NAME(""), .INTERFACE_NAME(""), .INTERFACE_LEVEL(3'b0)
+        , .SOFTRESET(1'b0), .SOFT_POWERDOWN_N(1'b1), .RFDIV_EN(1'b1), .OUT0_DIV_EN(1'b1)
+        , .OUT1_DIV_EN(1'b0), .OUT2_DIV_EN(1'b0), .OUT3_DIV_EN(1'b0), .SOFT_REF_CLK_SEL(1'b0)
+        , .RESET_ON_LOCK(1'b1), .BYPASS_CLK_SEL(4'b0), .BYPASS_GO_EN_N(1'b1)
+        , .BYPASS_PLL(4'b0), .BYPASS_OUT_DIVIDER(4'b0), .FF_REQUIRES_LOCK(1'b0)
+        , .FSE_N(1'b0), .FB_CLK_SEL_0(2'b00), .FB_CLK_SEL_1(1'b0), .RFDIV(6'b000001)
+        , .FRAC_EN(1'b0), .FRAC_DAC_EN(1'b0), .DIV0_RST_DELAY(3'b000)
+        , .DIV0_VAL(7'b0011001), .DIV1_RST_DELAY(3'b0), .DIV1_VAL(7'b1)
+        , .DIV2_RST_DELAY(3'b0), .DIV2_VAL(7'b1), .DIV3_RST_DELAY(3'b0)
+        , .DIV3_VAL(7'b1), .DIV3_CLK_SEL(1'b0), .BW_INT_CTRL(2'b0), .BW_PROP_CTRL(2'b01)
+        , .IREF_EN(1'b1), .IREF_TOGGLE(1'b0), .LOCK_CNT(4'b1000), .DESKEW_CAL_CNT(3'b110)
+        , .DESKEW_CAL_EN(1'b1), .DESKEW_CAL_BYPASS(1'b0), .SYNC_REF_DIV_EN(1'b0)
+        , .SYNC_REF_DIV_EN_2(1'b0), .OUT0_PHASE_SEL(3'b000), .OUT1_PHASE_SEL(3'b0)
+        , .OUT2_PHASE_SEL(3'b0), .OUT3_PHASE_SEL(3'b0), .SOFT_LOAD_PHASE_N(1'b1)
+        , .SSM_DIV_VAL(6'b1), .FB_FRAC_VAL(24'b0), .SSM_SPREAD_MODE(1'b0)
+        , .SSM_MODULATION(5'b00101), .FB_INT_VAL(12'b000001100100), .SSM_EN_N(1'b1)
+        , .SSM_EXT_WAVE_EN(2'b0), .SSM_EXT_WAVE_MAX_ADDR(8'b0), .SSM_RANDOM_EN(1'b0)
+        , .SSM_RANDOM_PATTERN_SEL(3'b0), .CDMUX0_SEL(2'b0), .CDMUX1_SEL(1'b1)
+        , .CDMUX2_SEL(1'b0), .CDELAY0_SEL(8'b0), .CDELAY0_EN(1'b0), .DRI_EN(1'b1)
+         )  pll_inst_0 (.LOCK(lock), .SSCG_WAVE_TABLE_ADDR({nc0,
+        nc1, nc2, nc3, nc4, nc5, nc6, nc7}), .DELAY_LINE_OUT_OF_RANGE()
+        , .POWERDOWN_N(vcc_net), .OUT0_EN(vcc_net), .OUT1_EN(gnd_net),
+        .OUT2_EN(gnd_net), .OUT3_EN(gnd_net), .REF_CLK_SEL(gnd_net),
+        .BYPASS_EN_N(vcc_net), .LOAD_PHASE_N(vcc_net),
+        .SSCG_WAVE_TABLE({gnd_net, gnd_net, gnd_net, gnd_net, gnd_net,
+        gnd_net, gnd_net, gnd_net}), .PHASE_DIRECTION(gnd_net),
+        .PHASE_ROTATE(gnd_net), .PHASE_OUT0_SEL(gnd_net),
+        .PHASE_OUT1_SEL(gnd_net), .PHASE_OUT2_SEL(gnd_net),
+        .PHASE_OUT3_SEL(gnd_net), .DELAY_LINE_MOVE(gnd_net),
+        .DELAY_LINE_DIRECTION(gnd_net), .DELAY_LINE_WIDE(gnd_net),
+        .DELAY_LINE_LOAD(vcc_net), .REFCLK_SYNC_EN(gnd_net),
+        .REF_CLK_0(clki), .REF_CLK_1(gnd_net), .FB_CLK(gnd_net),
+        .OUT0(pll_inst_0_clkint_0), .OUT1(), .OUT2(), .OUT3(),
+        .DRI_CLK(gnd_net), .DRI_CTRL({gnd_net, gnd_net, gnd_net,
+        gnd_net, gnd_net, gnd_net, gnd_net, gnd_net, gnd_net, gnd_net,
+        gnd_net}), .DRI_WDATA({gnd_net, gnd_net, gnd_net, gnd_net,
+        gnd_net, gnd_net, gnd_net, gnd_net, gnd_net, gnd_net, gnd_net,
+        gnd_net, gnd_net, gnd_net, gnd_net, gnd_net, gnd_net, gnd_net,
+        gnd_net, gnd_net, gnd_net, gnd_net, gnd_net, gnd_net, gnd_net,
+        gnd_net, gnd_net, gnd_net, gnd_net, gnd_net, gnd_net, gnd_net,
+        gnd_net}), .DRI_ARST_N(vcc_net), .DRI_RDATA({nc8, nc9, nc10,
+        nc11, nc12, nc13, nc14, nc15, nc16, nc17, nc18, nc19, nc20,
+        nc21, nc22, nc23, nc24, nc25, nc26, nc27, nc28, nc29, nc30,
+        nc31, nc32, nc33, nc34, nc35, nc36, nc37, nc38, nc39, nc40}),
+        .DRI_INTERRUPT());
+    VCC vcc_inst (.Y(vcc_net));
+    GND gnd_inst (.Y(gnd_net));
+
+endmodule

--- a/toplevel.v
+++ b/toplevel.v
@@ -14,7 +14,7 @@ module toplevel #(
   reg reset_out;
   wire lock;
 
-  pll chiselwatt_pll(
+  Chiselwatt_pll chiselwatt_pll(
     .clki(clock),
     .clko(clock_out),
     .lock(lock)


### PR DESCRIPTION
This PR adds support for Polarfire FPGA from Microchip/Microsemi.
The support has also been added to Fusesoc .core file to use the
soon-to-be merged Libero backend.

- Due to a tool incompatibility, Libero does not accept a module
named "pll". Due to this, I've renamed the PLLs to Chiselwatt_pll.
- Fixed formatting for chiselwatt.core file according to YAML lexer.
- Added micropython and helloworls filesets to .core so it's possible to
override the .hex to be used on core generation.

Demo of hello_world and Micropython:
https://twitter.com/carlosedp/status/1362119833324826626