### PR TITLE
Add syscon regsiters to the loadstore unit

### DIFF
--- a/src/main/scala/Core.scala
+++ b/src/main/scala/Core.scala
@@ -6,7 +6,7 @@ import Control._
 import Helpers._
 import InstructionHelpers._
 
-class Core(bits: Int, memSize: Int, memFileName: String, resetAddr: Int) extends Module {
+class Core(bits: Int, memSize: Int, memFileName: String, resetAddr: Int, clockFreq: Int) extends Module {
   val io = IO(new Bundle {
     val tx = Output(UInt(1.W))
     val rx = Input(UInt(1.W))
@@ -40,7 +40,7 @@ class Core(bits: Int, memSize: Int, memFileName: String, resetAddr: Int) extends
   val multiplier = Module(new SimpleMultiplier(bits))
   val divider = Module(new SimpleDivider(bits))
   val mem = Module(new MemoryBlackBoxWrapper(bits, memWords, memFileName))
-  val loadStore = Module(new LoadStore(bits, memWords))
+  val loadStore = Module(new LoadStore(bits, memWords, clockFreq))
   val control = Module(new Control(bits))
 
   val regFile = Module(new RegisterFile(32, bits, 3, 1, false))
@@ -445,5 +445,5 @@ class Core(bits: Int, memSize: Int, memFileName: String, resetAddr: Int) extends
 }
 
 object CoreObj extends App {
-  (new ChiselStage).emitVerilog(new Core(64, 384*1024, "insns.hex", 0x0))
+  (new ChiselStage).emitVerilog(new Core(64, 384*1024, "insns.hex", 0x0, 50000000))
 }

--- a/src/main/scala/LoadStore.scala
+++ b/src/main/scala/LoadStore.scala
@@ -32,7 +32,7 @@ class LoadStoreInput(val bits: Int) extends Bundle {
  *   2C: form store mask, store data
  */
 
-class LoadStore(val bits: Int, val words: Int) extends Module {
+class LoadStore(val bits: Int, val words: Int, val clockFreq: Int) extends Module {
   val io = IO(new Bundle {
     val in  = Flipped(Valid(new LoadStoreInput(bits)))
     val out = Output(Valid(UInt(bits.W)))
@@ -166,7 +166,7 @@ class LoadStore(val bits: Int, val words: Int) extends Module {
         }
         when (addr(7, 0) === "h20".U) {
           /* SYS_REG_CLKINFO */
-          data := 50000000.U
+          data := clockFreq.asUInt(bits.W)
         }
       }
 
@@ -203,13 +203,13 @@ class LoadStore(val bits: Int, val words: Int) extends Module {
   }
 }
 
-class LoadStoreWrapper(val bits: Int, val size: Int, filename: String) extends Module {
+class LoadStoreWrapper(val bits: Int, val size: Int, val clockFreq: Int, filename: String) extends Module {
   val io = IO(new Bundle {
     val in  = Flipped(Valid(new LoadStoreInput(bits)))
     val out = Output(Valid(UInt(bits.W)))
   })
 
-  val loadStore = Module(new LoadStore(bits, size/(bits/8)))
+  val loadStore = Module(new LoadStore(bits, size/(bits/8), clockFreq))
   val mem = Module(new MemoryBlackBoxWrapper(bits, size/(bits/8), filename))
 
   io.in <> loadStore.io.in
@@ -226,5 +226,5 @@ class LoadStoreWrapper(val bits: Int, val size: Int, filename: String) extends M
 }
 
 object LoadStoreObj extends App {
-  (new ChiselStage).emitVerilog(new LoadStoreWrapper(64, 128*1024, "test.hex"))
+  (new ChiselStage).emitVerilog(new LoadStoreWrapper(64, 128*1024, 50000000, "test.hex"))
 }

--- a/src/main/scala/LoadStore.scala
+++ b/src/main/scala/LoadStore.scala
@@ -150,6 +150,26 @@ class LoadStore(val bits: Int, val words: Int) extends Module {
         data := d.zeroExtend(length)
       }
 
+      /* Syscon */
+      when (addr(31, 8) === "hc00000".U) {
+        when (addr(7, 0) === "h00".U) {
+          /* SYS_REG_SIGNATURE */
+          data := "hf00daa5500010001".U
+        }
+        when (addr(7, 0) === "h08".U) {
+          /*
+           * SYS_REG_INFO
+           *  SYS_REG_INFO_HAS_UART is true
+           *  Other bits are false
+           */
+          data := "h1".U
+        }
+        when (addr(7, 0) === "h20".U) {
+          /* SYS_REG_CLKINFO */
+          data := 50000000.U
+        }
+      }
+
       /* UART */
       when (addr(31, 8) === "hc00020".U) {
         when (addr(7, 0) === "h08".U) {


### PR DESCRIPTION
In https://github.com/micropython/micropython/issues/6937 @carlosedp points out that micropython suffers from the lack of syscon registers in chiselwatt. This is a really simple implementation that should get it going.