### PR TITLE
upgrade to Chisel 3.5.0 (new stable)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 // See README.md for license details.
 
 
-ThisBuild / scalaVersion     := "2.12.12"
+ThisBuild / scalaVersion     := "2.12.15"
 ThisBuild / version          := "3.2.0"
 
 
@@ -9,17 +9,14 @@ lazy val root = (project in file("."))
   .settings(
     name := "chiselwatt",
     libraryDependencies ++= Seq(
-      "edu.berkeley.cs" %% "chisel3" % "3.4.1",
-      "edu.berkeley.cs" %% "chiseltest" % "0.3.1" % "test"
-      "edu.berkeley.cs" %% "scalatest" % "3.0.4" % "test"
+      "edu.berkeley.cs" %% "chisel3" % "3.5.0-RC2",
+      "edu.berkeley.cs" %% "chiseltest" % "0.5.0-RC2" % "test"
     ),
     scalacOptions ++= Seq(
-      "-Xsource:2.11",
       "-language:reflectiveCalls",
       "-deprecation",
       "-feature",
       "-Xcheckinit"
     ),
-    addCompilerPlugin("edu.berkeley.cs" % "chisel3-plugin" % "3.4.1" cross CrossVersion.full),
-    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full)
+    addCompilerPlugin("edu.berkeley.cs" % "chisel3-plugin" % "3.5.0-RC2" cross CrossVersion.full),
   )

--- a/build.sbt
+++ b/build.sbt
@@ -9,8 +9,8 @@ lazy val root = (project in file("."))
   .settings(
     name := "chiselwatt",
     libraryDependencies ++= Seq(
-      "edu.berkeley.cs" %% "chisel3" % "3.5.0-RC2",
-      "edu.berkeley.cs" %% "chiseltest" % "0.5.0-RC2" % "test"
+      "edu.berkeley.cs" %% "chisel3" % "3.5.0",
+      "edu.berkeley.cs" %% "chiseltest" % "0.5.0" % "test"
     ),
     scalacOptions ++= Seq(
       "-language:reflectiveCalls",
@@ -18,5 +18,5 @@ lazy val root = (project in file("."))
       "-feature",
       "-Xcheckinit"
     ),
-    addCompilerPlugin("edu.berkeley.cs" % "chisel3-plugin" % "3.5.0-RC2" cross CrossVersion.full),
+    addCompilerPlugin("edu.berkeley.cs" % "chisel3-plugin" % "3.5.0" cross CrossVersion.full),
   )

--- a/build.sc
+++ b/build.sc
@@ -19,7 +19,7 @@ trait HasXsource211 extends ScalaModule {
 
 trait HasChisel3 extends ScalaModule {
   override def ivyDeps = Agg(
-    ivy"edu.berkeley.cs::chisel3:3.5.0-RC2"
+    ivy"edu.berkeley.cs::chisel3:3.5.0"
   )
   // These lines are needed to use snapshot version of Chisel.
   def repositories = super.repositories ++ Seq(
@@ -30,7 +30,7 @@ trait HasChisel3 extends ScalaModule {
 trait HasChiselTests extends CrossSbtModule  {
   object test extends Tests {
     override def ivyDeps = Agg(
-      ivy"edu.berkeley.cs::chiseltest:0.5.0-RC2"
+      ivy"edu.berkeley.cs::chiseltest:0.5.0"
     )
     // These lines are needed to use snapshot version of Chisel.
     def repositories = super.repositories ++ Seq(

--- a/build.sc
+++ b/build.sc
@@ -19,7 +19,7 @@ trait HasXsource211 extends ScalaModule {
 
 trait HasChisel3 extends ScalaModule {
   override def ivyDeps = Agg(
-    ivy"edu.berkeley.cs::chisel3:3.4.+"
+    ivy"edu.berkeley.cs::chisel3:3.5.0-RC2"
   )
   // These lines are needed to use snapshot version of Chisel.
   def repositories = super.repositories ++ Seq(
@@ -30,8 +30,7 @@ trait HasChisel3 extends ScalaModule {
 trait HasChiselTests extends CrossSbtModule  {
   object test extends Tests {
     override def ivyDeps = Agg(
-      ivy"org.scalatest::scalatest:3.0.4",
-      ivy"edu.berkeley.cs::chiseltest:0.3.0"
+      ivy"edu.berkeley.cs::chiseltest:0.5.0-RC2"
     )
     // These lines are needed to use snapshot version of Chisel.
     def repositories = super.repositories ++ Seq(
@@ -41,15 +40,9 @@ trait HasChiselTests extends CrossSbtModule  {
   }
 }
 
-trait HasMacroParadise extends ScalaModule {
-  // Enable macro paradise for @chiselName et al
-  val macroPlugins = Agg(ivy"org.scalamacros:::paradise:2.1.0")
-  def scalacPluginIvyDeps = macroPlugins
-  def compileIvyDeps = macroPlugins
-}
 
-object chiselwatt extends CrossSbtModule with HasChisel3 with HasChiselTests with HasXsource211 with HasMacroParadise {
+object chiselwatt extends CrossSbtModule with HasChisel3 with HasChiselTests with HasXsource211 {
   override def millSourcePath = super.millSourcePath
-  def crossScalaVersion = "2.12.10"
+  def crossScalaVersion = "2.12.15"
   def mainClass = Some("CoreObj")
 }

--- a/src/main/scala/Core.scala
+++ b/src/main/scala/Core.scala
@@ -411,11 +411,11 @@ class Core(bits: Int, memSize: Int, memFileName: String, resetAddr: Int, clockFr
   when (wbLoadStoreRegValid) {
     regFile.io.wr(0).bits.addr := wbLoadStoreRegAddr
     regFile.io.wr(0).bits.data := memAdderOut
-    regFile.io.wr(0).fire() := true.B
+    regFile.io.wr(0).valid := true.B
   }. otherwise {
     regFile.io.wr(0).bits.addr := wbRegAddr
     regFile.io.wr(0).bits.data := wbRegData2
-    regFile.io.wr(0).fire() := (wbFast && wbRegValid) || multiplier.io.out.valid || divider.io.out.valid
+    regFile.io.wr(0).valid := (wbFast && wbRegValid) || multiplier.io.out.valid || divider.io.out.valid
   }
 
   when (wbFast && wbCarryValid) {

--- a/src/main/scala/RegisterFile.scala
+++ b/src/main/scala/RegisterFile.scala
@@ -29,10 +29,10 @@ class RegisterFile(numRegs: Int, bits: Int, numReadPorts: Int, numWritePorts: In
   val regs = Mem(numRegs, UInt(bits.W))
 
   io.rd.foreach{i => i.data := regs.read(i.addr)}
-  io.wr.foreach{i => when (i.fire()) { regs.write(i.bits.addr, i.bits.data) } }
+  io.wr.foreach{i => when (i.fire) { regs.write(i.bits.addr, i.bits.data) } }
 
   if (bypass) {
-    io.rd.foreach{r => io.wr.foreach{w => when (w.fire() && w.bits.addr === r.addr) { r.data := w.bits.data } } }
+    io.rd.foreach{r => io.wr.foreach{w => when (w.fire && w.bits.addr === r.addr) { r.data := w.bits.data } } }
   }
 }
 

--- a/src/test/scala/CountZeroes.scala
+++ b/src/test/scala/CountZeroes.scala
@@ -1,10 +1,9 @@
-import org.scalatest._
-import chisel3.tester._
 import chisel3._
-
+import chiseltest._
 import TestValues._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class CountZeroesUnitTester extends FlatSpec with ChiselScalatestTester with Matchers {
+class CountZeroesUnitTester extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "CountZeroes"
   it should "pass a unit test" in {
     test(new CountZeroes(64)) { c =>

--- a/src/test/scala/LoadStore.scala
+++ b/src/test/scala/LoadStore.scala
@@ -1,19 +1,13 @@
-import org.scalatest._
-import chisel3.tester._
 import chisel3._
-
-import chiseltest.experimental.TestOptionBuilder._
-import chiseltest.internal.{VerilatorBackendAnnotation, WriteVcdAnnotation}
-
-import treadle.executable.ClockInfo
-import treadle.{ClockInfoAnnotation}
-
+import chiseltest._
 import Control._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class LoadStoreUnitTester extends FlatSpec with ChiselScalatestTester with Matchers {
+class LoadStoreUnitTester extends AnyFlatSpec with ChiselScalatestTester {
   val bits = 64
   val words = 1024
   val filename = "LoadStoreInsns.hex"
+  val frequency = 50000000
 
   private def doOneRead(m: LoadStoreWrapper, a: UInt, b: UInt, length: UInt, signed: UInt, byteReverse: UInt, expected: UInt) = {
       m.io.in.bits.a.poke(a)
@@ -65,7 +59,8 @@ class LoadStoreUnitTester extends FlatSpec with ChiselScalatestTester with Match
 
   behavior of "LoadStore"
   it should "pass a unit test" in {
-    test(new LoadStoreWrapper(bits, words, filename)).withAnnotations(Seq(VerilatorBackendAnnotation, WriteVcdAnnotation, ClockInfoAnnotation(Seq(ClockInfo(period = 2))))) { m =>
+    test(new LoadStoreWrapper(bits, words, frequency, filename))
+      .withAnnotations(Seq(VerilatorBackendAnnotation, WriteVcdAnnotation)) { m =>
 
       doOneRead(m, 0.U, 0.U, LEN_1B, 0.U, 0.U, "h07".U)
       doOneRead(m, 0.U, 0.U, LEN_2B, 0.U, 0.U, "h0607".U)

--- a/src/test/scala/LoadStoreByteReverse.scala
+++ b/src/test/scala/LoadStoreByteReverse.scala
@@ -1,10 +1,9 @@
-import org.scalatest._
-import chisel3.tester._
 import chisel3._
-
+import chiseltest._
 import Control._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class LoadStoreByteReverseTester extends FlatSpec with ChiselScalatestTester with Matchers {
+class LoadStoreByteReverseTester extends AnyFlatSpec with ChiselScalatestTester  {
   val x = BigInt("0123456789ABCDEF", 16)
   val bits = 64
 

--- a/src/test/scala/MemoryBlackBox.scala
+++ b/src/test/scala/MemoryBlackBox.scala
@@ -1,15 +1,8 @@
-import org.scalatest._
-import chisel3.tester._
 import chisel3._
+import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
 
-import chiseltest.experimental.TestOptionBuilder._
-import chiseltest.internal.{VerilatorBackendAnnotation, WriteVcdAnnotation}
-
-import treadle.executable.ClockInfo
-import treadle.{ClockInfoAnnotation}
-
-
-class MemoryBlackBoxUnitTester extends FlatSpec with ChiselScalatestTester with Matchers {
+class MemoryBlackBoxUnitTester extends AnyFlatSpec with ChiselScalatestTester {
   val bits = 64
   val words = 1024
   val filename = "MemoryBlackBoxInsns.hex"
@@ -18,7 +11,7 @@ class MemoryBlackBoxUnitTester extends FlatSpec with ChiselScalatestTester with 
 
   behavior of "MemoryBlackBox"
   it should "pass a unit test" in {
-    test(new MemoryBlackBoxWrapper(bits, words, filename)).withAnnotations(Seq(VerilatorBackendAnnotation, WriteVcdAnnotation, ClockInfoAnnotation(Seq(ClockInfo(period = 2))))) { m =>
+    test(new MemoryBlackBoxWrapper(bits, words, filename)).withAnnotations(Seq(VerilatorBackendAnnotation, WriteVcdAnnotation)) { m =>
 
       m.io.fetchPort.addr.poke(0.U)
 

--- a/src/test/scala/PopulationCount.scala
+++ b/src/test/scala/PopulationCount.scala
@@ -1,11 +1,10 @@
-import org.scalatest._
-import chisel3.tester._
 import chisel3._
-
+import chiseltest._
 import Control._
 import TestValues._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class PopulationCountUnitTester extends FlatSpec with ChiselScalatestTester with Matchers {
+class PopulationCountUnitTester extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "PopulationCount"
 
   private def popcntb(x: BigInt): BigInt = {

--- a/src/test/scala/RegisterFile.scala
+++ b/src/test/scala/RegisterFile.scala
@@ -1,8 +1,8 @@
-import org.scalatest._
-import chisel3.tester._
 import chisel3._
+import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class RegisterFileUnitTester extends FlatSpec with ChiselScalatestTester with Matchers {
+class RegisterFileUnitTester extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "RegisterFile"
 
   it should "pass a unit test" in {
@@ -12,13 +12,13 @@ class RegisterFileUnitTester extends FlatSpec with ChiselScalatestTester with Ma
       println("RegisterFileUnitTester begin")
 
       // Write initial values to registers
-      r.io.wr(0).fire().poke(true.B)
+      r.io.wr(0).valid.poke(true.B)
       for (x <- (0 until numRegs)) {
         r.io.wr(0).bits.data.poke(x.U)
         r.io.wr(0).bits.addr.poke(x.U)
         r.clock.step()
       }
-      r.io.wr(0).fire().poke(false.B)
+      r.io.wr(0).valid.poke(false.B)
       r.clock.step()
 
       // Read them back
@@ -31,11 +31,11 @@ class RegisterFileUnitTester extends FlatSpec with ChiselScalatestTester with Ma
       }
 
       // Check bypassing works
-      r.io.wr(0).fire().poke(true.B)
+      r.io.wr(0).valid.poke(true.B)
       r.io.wr(0).bits.data.poke("hBADC0FFEE0DDF00D".U)
       r.io.wr(0).bits.addr.poke(11.U)
 
-      r.io.wr(1).fire().poke(true.B)
+      r.io.wr(1).valid.poke(true.B)
       r.io.wr(1).bits.data.poke("hFEE1DEADABADCAFE".U)
       r.io.wr(1).bits.addr.poke(24.U)
 
@@ -45,8 +45,8 @@ class RegisterFileUnitTester extends FlatSpec with ChiselScalatestTester with Ma
       r.io.rd(1).data.expect("hFEE1DEADABADCAFE".U)
       r.clock.step()
 
-      r.io.wr(0).fire().poke(false.B)
-      r.io.wr(1).fire().poke(false.B)
+      r.io.wr(0).valid.poke(false.B)
+      r.io.wr(1).valid.poke(false.B)
       r.clock.step()
 
       r.io.rd(0).data.expect("hBADC0FFEE0DDF00D".U)

--- a/src/test/scala/SimpleDivider.scala
+++ b/src/test/scala/SimpleDivider.scala
@@ -1,10 +1,9 @@
-import org.scalatest._
-import chisel3.tester._
 import chisel3._
-
+import chiseltest._
 import TestValues._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class SimpleDividerUnitTester extends FlatSpec with ChiselScalatestTester with Matchers {
+class SimpleDividerUnitTester extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "SimpleDivider"
 
   val tests = for {

--- a/src/test/scala/SimpleMultiplier.scala
+++ b/src/test/scala/SimpleMultiplier.scala
@@ -1,10 +1,9 @@
-import org.scalatest._
-import chisel3.tester._
 import chisel3._
-
+import chiseltest._
 import TestValues._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class SimpleMultiplierUnitTester extends FlatSpec with ChiselScalatestTester with Matchers {
+class SimpleMultiplierUnitTester extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "SimpleMultiplier"
 
   val tests = for {

--- a/src/test/scala/Uart.scala
+++ b/src/test/scala/Uart.scala
@@ -1,12 +1,8 @@
-import org.scalatest._
-import chisel3.tester._
 import chisel3._
+import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
 
-import chiseltest.experimental.TestOptionBuilder._
-
-import treadle.{WriteVcdAnnotation}
-
-class UartUnitTester extends FlatSpec with ChiselScalatestTester with Matchers {
+class UartUnitTester extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Uart"
 
   val rxOverclock = 16


### PR DESCRIPTION
This PR upgrades chiselwatt to work with the most recent 3.5 release of Chisel.